### PR TITLE
Add missing dialplan functions and applications

### DIFF
--- a/asterisklint/app/v11/app_db.py
+++ b/asterisklint/app/v11/app_db.py
@@ -1,0 +1,1 @@
+../vall/app_db.py

--- a/asterisklint/app/v11/func_odbc.py
+++ b/asterisklint/app/v11/func_odbc.py
@@ -1,0 +1,1 @@
+../vall/func_odbc.py

--- a/asterisklint/app/v13/app_bridgeaddchan.py
+++ b/asterisklint/app/v13/app_bridgeaddchan.py
@@ -1,0 +1,1 @@
+../vall/app_bridgeaddchan.py

--- a/asterisklint/app/v13/app_bridgewait.py
+++ b/asterisklint/app/v13/app_bridgewait.py
@@ -1,0 +1,1 @@
+../vall/app_bridgewait.py

--- a/asterisklint/app/v13/app_db.py
+++ b/asterisklint/app/v13/app_db.py
@@ -1,0 +1,1 @@
+../vall/app_db.py

--- a/asterisklint/app/v13/func_odbc.py
+++ b/asterisklint/app/v13/func_odbc.py
@@ -1,0 +1,1 @@
+../vall/func_odbc.py

--- a/asterisklint/app/vall/app_bridgeaddchan.py
+++ b/asterisklint/app/vall/app_bridgeaddchan.py
@@ -1,0 +1,24 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2015-2016  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import AppBase
+
+
+class BridgeAdd(AppBase):
+    pass
+
+
+def register(app_loader):
+    app_loader.register(BridgeAdd())

--- a/asterisklint/app/vall/app_bridgewait.py
+++ b/asterisklint/app/vall/app_bridgewait.py
@@ -1,0 +1,24 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2015-2016  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import AppBase
+
+
+class BridgeWait(AppBase):
+    pass
+
+
+def register(app_loader):
+    app_loader.register(BridgeWait())

--- a/asterisklint/app/vall/app_db.py
+++ b/asterisklint/app/vall/app_db.py
@@ -1,0 +1,24 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2015-2016  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import AppBase
+
+
+class DBdeltree(AppBase):
+    pass
+
+
+def register(app_loader):
+    app_loader.register(DBdeltree())

--- a/asterisklint/app/vall/builtin.py
+++ b/asterisklint/app/vall/builtin.py
@@ -53,6 +53,10 @@ class Background(BuiltinAppBase):
         return super().check_availability(supplied_name, where)
 
 
+class Bridge(BuiltinAppBase):
+    pass
+
+
 class Busy(BuiltinAppBase):
     pass
 
@@ -171,7 +175,7 @@ class WaitExten(BuiltinAppBase):
 
 def register(app_loader):
     for app in (
-            Answer, Background, Busy,
+            Answer, Background, Bridge, Busy,
             Congestion, Goto, GotoIf,
             GotoIfTime, ExecIfTime,
             Hangup, NoOp, Proceeding,

--- a/asterisklint/app/vall/func_odbc.py
+++ b/asterisklint/app/vall/func_odbc.py
@@ -1,0 +1,24 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2019  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import AppBase
+
+
+class ODBCFinish(AppBase):
+    pass
+
+
+def register(app_loader):
+    app_loader.register(ODBCFinish())

--- a/asterisklint/func/v11/func_base64.py
+++ b/asterisklint/func/v11/func_base64.py
@@ -1,0 +1,1 @@
+../vall/func_base64.py

--- a/asterisklint/func/v11/func_devstate.py
+++ b/asterisklint/func/v11/func_devstate.py
@@ -1,0 +1,1 @@
+../vall/func_devstate.py

--- a/asterisklint/func/v11/func_dialgroup.py
+++ b/asterisklint/func/v11/func_dialgroup.py
@@ -1,0 +1,1 @@
+../vall/func_dialgroup.py

--- a/asterisklint/func/v11/func_dialplan.py
+++ b/asterisklint/func/v11/func_dialplan.py
@@ -1,0 +1,1 @@
+../vall/func_dialplan.py

--- a/asterisklint/func/v11/func_odbc.py
+++ b/asterisklint/func/v11/func_odbc.py
@@ -1,0 +1,1 @@
+../vall/func_odbc.py

--- a/asterisklint/func/v13/chan_pjsip.py
+++ b/asterisklint/func/v13/chan_pjsip.py
@@ -1,0 +1,1 @@
+../vall/chan_pjsip.py

--- a/asterisklint/func/v13/func_base64.py
+++ b/asterisklint/func/v13/func_base64.py
@@ -1,0 +1,1 @@
+../vall/func_base64.py

--- a/asterisklint/func/v13/func_devstate.py
+++ b/asterisklint/func/v13/func_devstate.py
@@ -1,0 +1,1 @@
+../vall/func_devstate.py

--- a/asterisklint/func/v13/func_dialgroup.py
+++ b/asterisklint/func/v13/func_dialgroup.py
@@ -1,0 +1,1 @@
+../vall/func_dialgroup.py

--- a/asterisklint/func/v13/func_dialplan.py
+++ b/asterisklint/func/v13/func_dialplan.py
@@ -1,0 +1,1 @@
+../vall/func_dialplan.py

--- a/asterisklint/func/v13/func_odbc.py
+++ b/asterisklint/func/v13/func_odbc.py
@@ -1,0 +1,1 @@
+../vall/func_odbc.py

--- a/asterisklint/func/v13/func_talkdetect.py
+++ b/asterisklint/func/v13/func_talkdetect.py
@@ -1,0 +1,1 @@
+../vall/func_talkdetect.py

--- a/asterisklint/func/vall/chan_pjsip.py
+++ b/asterisklint/func/vall/chan_pjsip.py
@@ -1,0 +1,52 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2020  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import FuncBase
+
+
+class PJSIP_DIAL_CONTACTS(FuncBase):
+    pass
+
+
+class PJSIP_DTMF_MODE(FuncBase):
+    pass
+
+
+class PJSIP_MEDIA_OFFER(FuncBase):
+    pass
+
+
+class PJSIP_MOH_PASSTHROUGH(FuncBase):
+    pass
+
+
+class PJSIP_PARSE_URI(FuncBase):
+    pass
+
+
+class PJSIP_SEND_SESSION_REFRESH(FuncBase):
+    pass
+
+
+def register(func_loader):
+    for func in (
+            PJSIP_DIAL_CONTACTS,
+            PJSIP_DTMF_MODE,
+            PJSIP_MEDIA_OFFER,
+            PJSIP_MOH_PASSTHROUGH,
+            PJSIP_PARSE_URI,
+            PJSIP_SEND_SESSION_REFRESH,
+            ):
+        func_loader.register(func())

--- a/asterisklint/func/vall/func_base64.py
+++ b/asterisklint/func/vall/func_base64.py
@@ -1,0 +1,32 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2015-2016  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import FuncBase
+
+
+class BASE64_ENCODE(FuncBase):
+    pass
+
+
+class BASE64_DECODE(FuncBase):
+    pass
+
+
+def register(func_loader):
+    for func in (
+            BASE64_ENCODE,
+            BASE64_DECODE,
+            ):
+        func_loader.register(func())

--- a/asterisklint/func/vall/func_devstate.py
+++ b/asterisklint/func/vall/func_devstate.py
@@ -1,0 +1,32 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2015-2016  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import FuncBase
+
+
+class DEVICE_STATE(FuncBase):
+    pass
+
+
+class HINT(FuncBase):
+    pass
+
+
+def register(func_loader):
+    for func in (
+            DEVICE_STATE,
+            HINT,
+            ):
+        func_loader.register(func())

--- a/asterisklint/func/vall/func_dialgroup.py
+++ b/asterisklint/func/vall/func_dialgroup.py
@@ -1,0 +1,24 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2017  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import FuncBase
+
+
+class DIALGROUP(FuncBase):
+    pass
+
+
+def register(func_loader):
+    func_loader.register(DIALGROUP())

--- a/asterisklint/func/vall/func_dialplan.py
+++ b/asterisklint/func/vall/func_dialplan.py
@@ -1,0 +1,32 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2015-2016  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import FuncBase
+
+
+class DIALPLAN_EXISTS(FuncBase):
+    pass
+
+
+class VALID_EXTEN(FuncBase):
+    pass
+
+
+def register(func_loader):
+    for func in (
+            DIALPLAN_EXISTS,
+            VALID_EXTEN,
+            ):
+        func_loader.register(func())

--- a/asterisklint/func/vall/func_odbc.py
+++ b/asterisklint/func/vall/func_odbc.py
@@ -1,0 +1,32 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2015-2016  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import FuncBase
+
+
+class ODBC_FETCH(FuncBase):
+    pass
+
+
+class SQL_ESC(FuncBase):
+    pass
+
+
+def register(func_loader):
+    for func in (
+            ODBC_FETCH,
+            SQL_ESC,
+            ):
+        func_loader.register(func())

--- a/asterisklint/func/vall/func_talkdetect.py
+++ b/asterisklint/func/vall/func_talkdetect.py
@@ -1,0 +1,24 @@
+# AsteriskLint -- an Asterisk PBX config syntax checker
+# Copyright (C) 2017  Walter Doekes, OSSO B.V.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..base import FuncBase
+
+
+class TALK_DETECT(FuncBase):
+    pass
+
+
+def register(func_loader):
+    func_loader.register(TALK_DETECT())


### PR DESCRIPTION
Adds the following apps:

- BridgeAdd
- BridgeWait
- DBdeltree
- Bridge
- ODBCFinish

Adds the following functions:

- PJSIP_DIAL_CONTACTS
- PJSIP_DTMF_MODE
- PJSIP_MEDIA_OFFER
- PJSIP_MOH_PASSTHROUGH
- PJSIP_SEND_SESSION_REFRESH
- BASE64_ENCODE
- BASE64_DECODE
- DEVICE_STATE
- HINT
- DIALGROUP
- DIALPLAN_EXISTS
- VALID_EXTEN
- ODBC_FETCH
- SQL_ESC
- TALK_DETECT